### PR TITLE
add indices to plugin JSON files

### DIFF
--- a/buttons/devicepluginbuttons.json
+++ b/buttons/devicepluginbuttons.json
@@ -20,21 +20,24 @@
                         {
                             "name": "name",
                             "type": "QString",
-                            "defaultValue": "Simple button device default name"
+                            "defaultValue": "Simple button device default name",
+                            "index" : 0
                         }
                     ],
                     "actionTypes": [
                         {
                             "id": "64c4ced5-9a1a-4858-81dd-1b5c94dba495",
                             "idName": "pressSimpleButton",
-                            "name": "press the button"
+                            "name": "press the button",
+                            "index" : 0
                         }
                     ],
                     "eventTypes": [
                         {
                             "id": "f9652210-9aed-4f38-8c19-2fd54f703fbe",
                             "idName": "simpleButtonPressed",
-                            "name": "button pressed"
+                            "name": "button pressed",
+                            "index" : 0
                         }
                     ]
                 },
@@ -50,7 +53,8 @@
                         {
                             "name": "name",
                             "type": "QString",
-                            "defaultValue": "Power button device default name"
+                            "defaultValue": "Power button device default name",
+                            "index" : 0
                         }
                     ],
                     "actionTypes": [
@@ -58,11 +62,13 @@
                             "id": "1e97a057-c525-463d-a593-9b8dce16645f",
                             "idName": "setPowerButton",
                             "name": "set power",
+                            "index" : 0,
                             "paramTypes": [
                                 {
                                     "name": "power",
                                     "type": "bool",
-                                    "defaultValue": false
+                                    "defaultValue": false,
+                                    "index" : 0
                                 }
                             ]
                         }
@@ -73,7 +79,8 @@
                             "idName": "power",
                             "name": "power",
                             "type": "bool",
-                            "defaultValue": false
+                            "defaultValue": false,
+                            "index" : 0
                         }
                     ]
                 },
@@ -89,7 +96,8 @@
                         {
                             "name": "name",
                             "type": "QString",
-                            "defaultValue": "Alternative power button device default name"
+                            "defaultValue": "Alternative power button device default name",
+                            "index" : 0
                         }
                     ],
                     "stateTypes": [
@@ -99,6 +107,7 @@
                             "name": "power",
                             "type": "bool",
                             "defaultValue": false,
+                            "index" : 0,
                             "writable": true
                         }
                     ]

--- a/coapclient/deviceplugincoapclient.json
+++ b/coapclient/deviceplugincoapclient.json
@@ -23,7 +23,8 @@
                             "name": "url",
                             "type": "QString",
                             "inputType": "TextLine",
-                            "defaultValue": "coap://vs0.inf.ethz.ch:5683"
+                            "defaultValue": "coap://vs0.inf.ethz.ch:5683",
+                            "index" : 0
                         }
                     ],
                     "stateTypes": [
@@ -33,6 +34,7 @@
                             "name": "notification",
                             "type": "bool",
                             "defaultValue": false,
+                            "index" : 0,
                             "writable": true
                         }
                     ],
@@ -41,11 +43,13 @@
                             "id": "9aa31838-b62f-43b3-bdcd-8165840b5edf",
                             "name": "upload message",
                             "idName": "upload",
+                            "index" : 0,
                             "paramTypes": [
                                 {
                                     "name": "message",
                                     "type": "QString",
-                                    "defaultValue": "Hallo world!"
+                                    "defaultValue": "Hallo world!",
+                                    "index" : 0
                                 }
                             ]
                         }
@@ -55,10 +59,12 @@
                             "name": "time changed",
                             "idName": "time",
                             "id": "44513802-138e-42f8-86a6-9edd4df77535",
+                            "index" : 0,
                             "paramTypes": [
                                 {
                                     "name": "time",
-                                    "type": "QString"
+                                    "type": "QString",
+                                    "index" : 0
                                 }
                             ]
                         }

--- a/minimal/devicepluginminimal.json
+++ b/minimal/devicepluginminimal.json
@@ -20,7 +20,8 @@
                         {
                             "name": "name",
                             "type": "QString",
-                            "defaultValue": "Minimal device default name"
+                            "defaultValue": "Minimal device default name",
+                            "index" : 0
                         }
                     ]
                 }

--- a/networkinfo/devicepluginnetworkinfo.json
+++ b/networkinfo/devicepluginnetworkinfo.json
@@ -20,7 +20,8 @@
                         {
                             "name": "name",
                             "type": "QString",
-                            "defaultValue": "Network Information"
+                            "defaultValue": "Network Information",
+                            "index" : 0
                         }
                     ],
                     "stateTypes": [
@@ -29,49 +30,56 @@
                             "id": "0b4751ca-f126-4369-bfc0-f745985ae59b",
                             "idName": "address",
                             "type": "QString",
-                            "defaultValue": "-"
+                            "defaultValue": "-",
+                            "index" : 0
                         },
                         {
                             "name": "city",
                             "id": "8c777cf7-1a54-4b80-a8fe-141ae2334a63",
                             "idName": "city",
                             "type": "QString",
-                            "defaultValue": "-"
+                            "defaultValue": "-",
+                            "index" : 1
                         },
                         {
                             "name": "country",
                             "id": "69a01d64-c68f-4175-85f3-69329fd66b52",
                             "idName": "country",
                             "type": "QString",
-                            "defaultValue": "-"
+                            "defaultValue": "-",
+                            "index" : 2
                         },
                         {
                             "name": "time zone",
                             "id": "ab5278ce-87e0-4a79-9d08-c989c50d62cb",
                             "idName": "timeZone",
                             "type": "QString",
-                            "defaultValue": "-"
+                            "defaultValue": "-",
+                            "index" : 3
                         },
                         {
                             "name": "lon",
                             "id": "5a3a54d3-afd4-464a-adba-23def0110ed7",
                             "idName": "lon",
                             "type": "double",
-                            "defaultValue": 0
+                            "defaultValue": 0,
+                            "index" : 4
                         },
                         {
                             "name": "lat",
                             "id": "f7b52b93-688d-47bb-83cc-85a694f33537",
                             "idName": "lat",
                             "type": "double",
-                            "defaultValue": 0
+                            "defaultValue": 0,
+                            "index" : 5
                         }
                     ],
                     "actionTypes": [
                         {
                             "id": "0b4751ca-f126-4369-bfc0-f745985ae59b",
                             "name": "update",
-                            "idName": "update"
+                            "idName": "update",
+                            "index" : 0
                         }
                     ]
                 }


### PR DESCRIPTION
Without indices, I get the following error:
>  W | DeviceManager: "Minimal" Error parsing ParamType: missing fields "index", QJsonObject({"defaultValue":"Minimal device default name","name":"name","type":"QString"})